### PR TITLE
Updated README example to use the locations v2 API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,8 @@ Making the diagnostic-tools API `locations` call:
 
 .. code-block:: bash
 
-	% http --auth-type edgegrid -a default: :/diagnostic-tools/v1/locations
-	
+	% http --auth-type edgegrid -a default: :/diagnostic-tools/v2/ghost-locations/available
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
When developers use the current example to retrieve the edge locations via the diagnostics API, all they get is a deprecation warning. This is because the v1 has been deprecated.

Here's the updated example using "/diagnostic-tools/v2/ghost-locations/available" so that first-time users actually have a nice experience and get the expected results.