### PR TITLE
Adds docker options for httpie-edgegrid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+#
+# httpie-edgegrid Dockerfile
+#
+
+FROM alpine:latest
+RUN apk update && apk upgrade
+RUN apk -uv add --no-cache python3 py3-pip build-base musl python3-dev libffi libffi-dev openssl-dev jq
+RUN pip3 install --no-cache-dir 'urllib3==1.22' --force-reinstall
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir cryptography httpie-edgegrid
+
+RUN rm -rf /var/cache/apk/*

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,16 @@ If you have problems intalling from sources, you could use pip:
 
     $ pip install httpie-edgegrid
 
+If using Docker:
 
-
+    Build:
+    docker build . -t httpie-edgegrid
+    
+    Run:
+    docker run -it httpie-edgegrid:latest
+    
+    Configuration:
+    For .edgerc or httpie configuration use /root for the home dir.
 
 Usage
 -----
@@ -86,3 +94,4 @@ Or with pip3:
 .. code-block:: bash
 
 	$ sudo pip3 install httpie-edgegrid
+


### PR DESCRIPTION
Builds ontop of #15

Uses a lightweight alpine distribution and provides a simple docker file for users. (additionally i recommend that Akamai publish the image to the docker registry maintained by Akamai (https://hub.docker.com/u/akamaiopen). Could save someone from a build step)